### PR TITLE
Fix install script on Windows

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1,5 +1,5 @@
 import {fileURLToPath} from 'node:url';
-import fs from 'node:fs/promises';
+import {promises as fs} from 'node:fs';
 import binBuild from 'bin-build';
 import bin from './index.js';
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,4 +1,5 @@
 import {fileURLToPath} from 'node:url';
+import fs from 'node:fs/promises';
 import binBuild from 'bin-build';
 import bin from './index.js';
 
@@ -13,10 +14,11 @@ bin.run([src, dest]).then(() => {
 	console.warn('guetzli pre-build test failed');
 	console.info('compiling from source');
 
+	await fs.mkdir(bin.dest(), {recursive: true});
+
 	try {
 		const source = fileURLToPath(new URL('../vendor/source/guetzli-1.0.1.tar.gz', import.meta.url));
 		binBuild.file(source, [
-			`mkdir -p ${bin.dest()}`,
 			`make && mv bin/Release/${bin.use()} ${bin.path()}`,
 		]);
 


### PR DESCRIPTION
On Windows, if `verdor` dir already exists, the `mkdir` command will fail.