### PR TITLE
Fix pre-build test

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"index.js",
 		"cli.js",
 		"lib",
-		"vendor/source"
+		"vendor/source",
+		"test/fixtures"
 	],
 	"keywords": [
 		"imagemin",


### PR DESCRIPTION
Pre-build test always fails because `test/fixtures` is not included in npm package.

```sh
> guetzli@5.0.0 postinstall ./node_modules/guetzli
> node lib/install.js

Command failed: ./node_modules/guetzli/vendor/guetzli ./node_modules/guetzli/test/fixtures/test.jpg ./node_modules/guetzli/test/fixtures/dest.jpg
Can't open input file


guetzli pre-build test failed
compiling from source
```