### PR TITLE
Fix postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"index.js",
 		"cli.js",
 		"lib",
+		"test/fixtures",
 		"vendor/source"
 	],
 	"keywords": [


### PR DESCRIPTION
Pre-build test always fails because `test/fixtures` is not included in npm package.

```sh
> guetzli@5.0.0 postinstall ./node_modules/guetzli
> node lib/install.js

Command failed: ./node_modules/guetzli/vendor/guetzli ./node_modules/guetzli/test/fixtures/test.jpg ./node_modules/guetzli/test/fixtures/dest.jpg
Can't open input file


guetzli pre-build test failed
compiling from source
```